### PR TITLE
Increased initial board size

### DIFF
--- a/hooks/useBoard.ts
+++ b/hooks/useBoard.ts
@@ -4,7 +4,7 @@ import { createRoot } from "react-dom/client";
 import { OnClickState } from "@/lib/enums";
 
 const useBoard = () => {
-  const [size, setSize] = useState([22, 22]);
+  const [size, setSize] = useState([25, 25]);
   const [start, setStart] = useState([1, 1]);
   const [end, setEnd] = useState([size[0] - 2, size[1] - 2]);
   const [isDrawing, setIsDrawing] = useState(false);


### PR DESCRIPTION
### Increase initial board size

**Summary:** The initial size of the board has been increased from 22x22 to 25x25 for enhanced gameplay experience.

**Changes:**
- useBoard.ts

**Impact:** The board's dimensions in the game are affected, which may alter the gameplay and user experience.
**Action Required:** Review and test the gameplay with the new board size to ensure balance and usability.